### PR TITLE
Updating EMC_post to NOAA-GSL fork.

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,6 +1,6 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/NOAA-GSD/regional_workflow
+repo_url = https://github.com/NOAA-GSL/regional_workflow
 # Specify either a branch name or a hash but not both.
 branch = feature/RRFS_dev1
 #hash = b2b7e959
@@ -27,7 +27,7 @@ required = True
 
 [ufs_weather_model]
 protocol = git
-repo_url = https://github.com/NOAA-GSD/ufs-weather-model
+repo_url = https://github.com/NOAA-GSL/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = gsd/develop
 hash = 05a5f1f
@@ -36,10 +36,10 @@ required = True
 
 [EMC_post]
 protocol = git
-repo_url = https://github.com/NOAA-EMC/EMC_post
+repo_url = https://github.com/NOAA-GSL/EMC_post
 # Specify either a branch name or a hash but not both.
-#branch = develop
-hash = dceca26
+#branch = RRFS_dev
+hash = 9b9c55c
 local_path = src/EMC_post
 required = True
 


### PR DESCRIPTION
This commit turns on the GSD ceiling diagnostic, providing numeric output instead of missing values in grib files.

Also updating path to other NOAA-GSL forks.

