### PR TITLE
RRFS_dev1: Add external for python_graphics.

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -34,5 +34,12 @@ hash = de76944
 local_path = src/EMC_post
 required = True
 
+[python_graphics]
+protocol = git
+repo_url = https://github.com/NOAA-GSL/adb_graphics
+hash = 7039a77
+local_path = python_graphics
+required = True
+
 [externals_description]
 schema_version = 1.0.0

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -37,7 +37,7 @@ required = True
 [python_graphics]
 protocol = git
 repo_url = https://github.com/NOAA-GSL/adb_graphics
-hash = 7039a77
+hash = 697ed3a
 local_path = python_graphics
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Add the NOAA-GSL adb_graphics repository as an external for running SkewT diagrams in real time.

## TESTS CONDUCTED: 
Ran tests under my user account to ensure that both AK and CONUS domains successfully used this external repo code.

## DEPENDENCIES
The code here needs to be updated with the appropriate hash after [NOAA-GSL:adb_graphics PR#66](https://github.com/NOAA-GSL/adb_graphics/pull/66) is merged. Then it should be fine to merge. For full utility, [NOAA-GSL:regional_workflow PR #40](https://github.com/NOAA-GSL/regional_workflow/pull/40) will also need to be merged.


