### PR TITLE
Add workflow environment settings for AWS

### DIFF
--- a/env/wflow_aws.env
+++ b/env/wflow_aws.env
@@ -1,0 +1,3 @@
+module use /contrib/apps/miniconda3/modulefiles
+module load miniconda3
+source activate regional_workflow


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Adds `env/wflow_aws.env` to enable proper environment for running workflows on AWS Parallel Works.

This PR is dependent on NOAA-GSL/regional_workflow#47 and should be merged at the same time.

## TESTS CONDUCTED: 
Ran end-to-end community workflow on Parallel Works with Rocoto and verified all tasks completed successfully.

## CONTRIBUTORS (optional): 
The environment loaded in `env/wflow_aws.env` was provided by @christinaholtNOAA 
