### PR TITLE
Updating Externals.cfg for RRFS-dev4

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -9,10 +9,10 @@ required = True
 
 [ufs_utils]
 protocol = git
-repo_url = https://github.com/NOAA-EMC/UFS_UTILS
+repo_url = https://github.com/NOAA-GSL/UFS_UTILS
 # Specify either a branch name or a hash but not both.
 #branch = develop
-hash = 005f9a0a
+hash = b87dec5
 local_path = src/UFS_UTILS
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
1) The URL for UFS_UTILS now points to GSL's fork
2) New hash pulls from RRFS_dev branch, utilizing recent updates to chgres_cube

## TESTS CONDUCTED: 
checkout_externals runs successfully, but no other tests have been conducted strictly for this PR.  However, the related PR for UFS_UTILS (see below) indicates successful tests of chgres_cube while utilizing operational and experimental RAP/HRRR.

## ISSUE (optional): 
See related PR for UFS_UTILS at https://github.com/NOAA-GSL/UFS_UTILS/pull/1

## CONTRIBUTORS (optional): 
@hu5970 @christinaholtNOAA 
