### PR TITLE
Fix AWS build environment to use EFA-enabled Intel MPI module

### DIFF
--- a/env/build_aws_intel.env
+++ b/env/build_aws_intel.env
@@ -15,5 +15,5 @@ export CXX=icpc
 export FC=ifort
 
 module load intel/19.0.5.281
-module load impi/2019.0.5
+module load intelmpi
 


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 
Update the build environment settings for AWS so that the Intel MPI enabled for the Elastic Fabric Adapter (EFA) is loaded. This is critical for performance because the default network fabric on AWS is very slow.

## TESTS CONDUCTED: 
Ran the community configuration as well as 3km domain multiple times with different layouts and threading.   Performance was verified to be more than 2x faster than previous runs without the EFA-enabled IMPI.

