### PR TITLE
Updating EMC_post hash

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -30,7 +30,7 @@ protocol = git
 repo_url = https://github.com/NOAA-GSL/EMC_post
 # Specify either a branch name or a hash but not both.
 #branch = RRFS_dev
-hash = de76944
+hash = b6e5b25
 local_path = src/EMC_post
 required = True
 


### PR DESCRIPTION
Updating hash for EMC_post

## DESCRIPTION OF CHANGES: 
This new hash pulls latest mods to EMC_post (RRFS_dev branch), to include updates to generating center, process ID, and revamped output. 

## TESTS CONDUCTED: 
Successful tests have been conducted in offline RRFS-dev4 cases. 

## CONTRIBUTORS (optional): 
@JeffBeck-NOAA @CurtisAlexander-NOAA 

