### PR TITLE
Update hash for EMC_post (dev2)

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -39,7 +39,7 @@ protocol = git
 repo_url = https://github.com/NOAA-GSL/EMC_post
 # Specify either a branch name or a hash but not both.
 # branch = RRFS_dev
-hash = 9b9c55c
+hash = b6e5b25
 local_path = src/EMC_post
 required = True
 


### PR DESCRIPTION
Updating hash for EMC_post

## DESCRIPTION OF CHANGES: 
This new hash pulls latest mods to EMC_post (RRFS_dev branch), to include updates to generating center, process ID, and revamped output.

## TESTS CONDUCTED: 
This update has been successfully deployed in RRFS-dev4 (CONUS).

## CONTRIBUTORS (optional): 
@christinaholtNOAA @hu5970 @JeffBeck-NOAA 

