### PR TITLE
Compile "FV3_GSD_v0" physics for RRFS 13-km NA

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ ExternalProject_Add(UFS_UTILS
   )
 
 if(NOT CCPP_SUITES)
-  set(CCPP_SUITES "FV3_GSD_SAR,FV3_HRRR")
+  set(CCPP_SUITES "FV3_GSD_SAR,FV3_HRRR,FV3_GSD_v0")
 endif()
 
 ExternalProject_Add(ufs_weather_model


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Enable "FV3_GSD_v0" CCPP suite (using GF deep convection) in support of RRFS 13-km NA. 

## TESTS CONDUCTED: 
This suite compiles and runs successfully in the prototype 13-km configuration.