### PR TITLE
Updating Externals.cfg hash for EMC_post to deploy bug fixes

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -30,7 +30,7 @@ protocol = git
 repo_url = https://github.com/NOAA-GSL/EMC_post
 # Specify either a branch name or a hash but not both.
 #branch = RRFS_dev
-hash = b6e5b25
+hash = 6ec6c91
 local_path = src/EMC_post
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This new EMC_post hash deploys recent UPP bug fixes.  See https://github.com/NOAA-GSL/EMC_post/commit/6ec6c91bfd19c41fc3377af3ef2665c0e0e1307f

## TESTS CONDUCTED: 
The associated UPP bug fix eliminates intermittent "run_post" crashes in the 13-km RRFS NA. 

## CONTRIBUTORS (optional): 
Thanks @SamuelTrahanNOAA for the bug fix.

