### PR TITLE
Enabling compilation of "FV3_RAP" CCPP suite

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ ExternalProject_Add(UFS_UTILS
   )
 
 if(NOT CCPP_SUITES)
-  set(CCPP_SUITES "FV3_GSD_SAR,FV3_HRRR,FV3_GSD_v0")
+  set(CCPP_SUITES "FV3_GSD_SAR,FV3_HRRR,FV3_RAP,FV3_GSD_v0")
 endif()
 
 ExternalProject_Add(ufs_weather_model


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Adding "FV3_RAP" to compiled CCPP suites.

## TESTS CONDUCTED: 
ufs_model compiles and runs successfully using the FV3_RAP suite; see the related PR for regional workflow at https://github.com/NOAA-GSL/regional_workflow/pull/76