### PR TITLE
rrfs_cloud: Adding NSSL Physics.

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -17,9 +17,10 @@ required = True
 
 [ufs_weather_model]
 protocol = git
-repo_url = https://github.com/NOAA-GSL/ufs-weather-model
+#repo_url = https://github.com/NOAA-GSL/ufs-weather-model
+repo_url = https://github.com/christinaholtNOAA/ufs-weather-model
 # Specify either a branch name or a hash but not both.
-branch = RRFS_cloud
+branch = rrfs_cloud_9mem
 #hash = 63591b6
 local_path = src/ufs_weather_model
 required = True

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,8 +1,8 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/christinaholtNOAA/regional_workflow
+repo_url = https://github.com/NOAA-GSL/regional_workflow
 # Specify either a branch name or a hash but not both.
-branch = add_configs
+branch = RRFS_cloud
 local_path = regional_workflow
 required = True
 
@@ -17,11 +17,9 @@ required = True
 
 [ufs_weather_model]
 protocol = git
-#repo_url = https://github.com/NOAA-GSL/ufs-weather-model
-repo_url = https://github.com/christinaholtNOAA/ufs-weather-model
+repo_url = https://github.com/NOAA-GSL/ufs-weather-model
 # Specify either a branch name or a hash but not both.
-branch = rrfs_cloud_hwt
-#hash = 63591b6
+branch = RRFS_cloud
 local_path = src/ufs_weather_model
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -20,7 +20,7 @@ protocol = git
 #repo_url = https://github.com/NOAA-GSL/ufs-weather-model
 repo_url = https://github.com/christinaholtNOAA/ufs-weather-model
 # Specify either a branch name or a hash but not both.
-branch = rrfs_cloud_9mem
+branch = rrfs_cloud_hwt
 #hash = 63591b6
 local_path = src/ufs_weather_model
 required = True

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,8 +1,8 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/NOAA-GSL/regional_workflow
+repo_url = https://github.com/christinaholtNOAA/regional_workflow
 # Specify either a branch name or a hash but not both.
-branch = RRFS_cloud
+branch = add_configs
 local_path = regional_workflow
 required = True
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ ExternalProject_Add(UFS_UTILS
   )
 
 if(NOT CCPP_SUITES)
-  set(CCPP_SUITES "rrfs_gfsv16,FV3_GFS_v15_thompson_mynn")
+  set(CCPP_SUITES "rrfs_gfsv16,FV3_GFS_v15_thompson_mynn,nssl_mp_no_nsst")
 endif()
 
 ExternalProject_Add(ufs_weather_model
@@ -22,5 +22,6 @@ ExternalProject_Add(ufs_weather_model
                "-DCMAKE_Fortran_COMPILER=${MPI_Fortran_COMPILER}"
                "-DSTATIC=Y"
                "-DNETCDF_DIR=$ENV{NETCDF}"
+               "-DAPP=ATM"
   INSTALL_COMMAND mkdir -p ${CMAKE_INSTALL_PREFIX}/bin && cp ${CMAKE_CURRENT_BINARY_DIR}/ufs_weather_model/src/ufs_weather_model-build/ufs_model ${CMAKE_INSTALL_PREFIX}/bin/
   )


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Add NSSL physics to the list of physics packages to build by default. The modifications to Externals.cfg should be removed once those PRs have been merged -- they're only here for easier testing purposes ATM.

## TESTS CONDUCTED: 
Built and run on Hera and AWS. Currently testing for unexpected answer changes compared to what was run during the HWT.

## Dependencies

- waiting on NOAA-GSL/fv3atm/pull/95
- waiting on NOAA-GSL/GFDL_atmos_cubed_sphere/pull/10
- waiting on NOAA-GSL/ufs-weather-model/pull/87
- waiting on NOAA-GSL/regional_workflow/pull/127