### PR TITLE
Fix Intel MPI module for AWS runs

### DIFF
--- a/env/build_aws_intel.env
+++ b/env/build_aws_intel.env
@@ -15,5 +15,5 @@ export CXX=icpc
 export FC=ifort
 
 module load intel/19.0.5.281
-module load impi/2019.0.5
+module load intelmpi  # DO NOT CHANGE: This specific module is needed on AWS for EFA support
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 

Fix the Intel MPI module being loaded for the AWS build/run environment.  The `intelmpi` module is required on AWS in order to get Elastic Fabric Adapter (EFA) support.

## TESTS CONDUCTED: 
Ran FFAIR workflow using regional_workflow on AWS using Parallel Works

## ISSUE (optional): 

None


