### PR TITLE
Updating EMC_post hash

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -30,7 +30,7 @@ protocol = git
 repo_url = https://github.com/NOAA-GSL/EMC_post
 # Specify either a branch name or a hash but not both.
 #branch = RRFS_dev
-hash = 6ec6c91
+hash = 5d8deea
 local_path = src/EMC_post
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Up to this point we have been using an old version of EMC_post (not yet merged with EMC's latest development) for RRFS CONUS runs, while the 3km NA domain has used the latest EMC development without recent GSL changes.  This PR updates the RRFS_dev1 EMC_post hash to point to recently merged code which includes recent development from both GSL and EMC.

## TESTS CONDUCTED: 
RRFS 3km CONUS and 13km NA were tested on Jet with the latest code, with identical results.  

## CONTRIBUTORS (optional): 
Tests were conducted by Guoqing Ge, Ming Hu, and Trevor Alcott.

