### PR TITLE
Update the python graphics hashtag to latest

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -37,7 +37,7 @@ required = True
 [python_graphics]
 protocol = git
 repo_url = https://github.com/NOAA-GSL/pygraf
-hash = 24daaf5
+hash = 82a5318
 local_path = python_graphics
 required = True
 


### PR DESCRIPTION
The hash for Python Graphics can be updated for the last few merged changes. This update includes 3 PRs, with the following changes:

changes to map labels to avoid overlap or extending too far
adding native level Smoke products
updating Wildfire Probability algorithm and adding for RRFS products

**TESTS CONDUCTED:**
Tests were conducted using the HRRR_NCEP and RRFS NA 3km python graphics runs and have been successful. We will monitor the graphics to make sure no issues arise.

**CONTRIBUTORS (optional):**
Brian Jamison
Craig Hartsough
Christina Holt