### PR TITLE
Updating EMC_post hash to include latest code for RRFS_NA_3km

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -30,7 +30,7 @@ protocol = git
 repo_url = https://github.com/NOAA-GSL/EMC_post
 # Specify either a branch name or a hash but not both.
 #branch = RRFS_dev
-hash = 5d8deea
+hash = e209338
 local_path = src/EMC_post
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Updated Externals.cfg with the latest hash for EMC_post RRFS_dev branch.  This code allows UPP to work for the 3km NA RRFS domain, including gridded FFG exceedances.

## TESTS CONDUCTED: 
This updated EMC_post code has been tested in retrospective mode on Jet, and is running in real-time in RRFS_NA_3km.
