### PR TITLE
Updating EMC_post hash

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -30,7 +30,7 @@ protocol = git
 repo_url = https://github.com/NOAA-GSL/EMC_post
 # Specify either a branch name or a hash but not both.
 #branch = RRFS_dev
-hash = e209338
+hash = 54c59e1
 local_path = src/EMC_post
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This PR updates the hash for EMC_post in Externals.cfg to the latest code version, which includes output of 9 soil levels for RUC LSM.

## TESTS CONDUCTED: 
The new UPP code has been tested on Jet for RRFS 3km NA and 13km NA domains.