### PR TITLE
UPP update

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -27,10 +27,10 @@ required = True
 
 [EMC_post]
 protocol = git
-repo_url = https://github.com/NOAA-GSL/EMC_post
+repo_url = https://github.com/NOAA-GSL/UPP
 # Specify either a branch name or a hash but not both.
 #branch = RRFS_dev
-hash = 05ffca2
+hash = b81fa4f
 local_path = src/EMC_post
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The name of the UPP repo has been changed from EMC_post to UPP, in order to be consistent with EMC.  This change uses the new name of the repo in Externals.cfg, and also updates the hash to the latest synced code.

## TESTS CONDUCTED: 
The app was built on Jet with the new Externals.cfg file.  Tests were also conducted on Jet for running UPP for the RRFS_NA_3km in retrospective mode, with no difference to GRIB2 output fields.  

## DEPENDENCIES:
None

