### PR TITLE
Updating UPP hash

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -30,7 +30,7 @@ protocol = git
 repo_url = https://github.com/NOAA-GSL/UPP
 # Specify either a branch name or a hash but not both.
 #branch = RRFS_dev
-hash = b81fa4f
+hash = ac752ec
 local_path = src/EMC_post
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This PR updates the hash for UPP to use the latest code, which includes a bug fix for 6 GRIB2 fields in the 0-h files that were incorrectly encoded and causing wgrib2 crashes.

## TESTS CONDUCTED: 
This change was tested in retrospective mode for the RRFS_NA_3km on Jet.

## DEPENDENCIES:
None

## DOCUMENTATION:
None

