### PR TITLE
Updating UPP hash to point to latest UPP code

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -30,7 +30,7 @@ protocol = git
 repo_url = https://github.com/NOAA-GSL/UPP
 # Specify either a branch name or a hash but not both.
 #branch = RRFS_dev
-hash = ac752ec
+hash = 82f3133
 local_path = src/EMC_post
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This PR updates the UPP hash to use the latest NOAA-GSL code, which includes RAP/HRRR like smoothing for certain fields in RRFS.  Note that it leads to a 40% slowdown in UPP; speeding up the smoothing is left for future work.

## TESTS CONDUCTED: 
The new UPP code was tested in retrospective mode with RRFS_NA_3km domain on Jet.

## DEPENDENCIES:
- NOAA-GSL/UPP/pull/22

## DOCUMENTATION:
None