### PR TITLE
Update the pygraf hash for RTMA. 

### DIFF
--- a/Externals.rtma
+++ b/Externals.rtma
@@ -38,7 +38,7 @@ required = True
 [python_graphics]
 protocol = git
 repo_url = https://github.com/NOAA-GSL/pygraf
-hash = f74700b
+hash = 239a3c9
 local_path = python_graphics
 required = True
 


### PR DESCRIPTION
Update pygraf hash for RTMA. This includes write capability for skewTs.


## DESCRIPTION OF CHANGES: 
This includes write capability for skewTs.

## DEPENDENCIES:
This is just like PR#147 for RRFS.


