### PR TITLE
Updating hash for UPP

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -30,7 +30,7 @@ protocol = git
 repo_url = https://github.com/NOAA-GSL/UPP
 # Specify either a branch name or a hash but not both.
 #branch = RRFS_dev
-hash = 82f3133
+hash = e4f0bc0
 local_path = src/EMC_post
 required = True
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Update hash for UPP to output soil moisture availability (MSTAV) from RRFS.

## TESTS CONDUCTED: 
This was tested in retrospective mode for RRFS_NA_3km on Jet.  Works with and without "wet1" available in the phyf*.nc files.

## DEPENDENCIES:
None

## DOCUMENTATION:
None