### PR TITLE
Updating UPP in Externals.cfg to point to EMC develop

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -27,10 +27,10 @@ required = True
 
 [EMC_post]
 protocol = git
-repo_url = https://github.com/NOAA-GSL/UPP
+repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
 #branch = RRFS_dev
-hash = 7d4d6d6
+hash = 7477b93
 local_path = src/EMC_post
 required = True
 externals = None


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Pointing to EMC develop UPP repository instead of GSL RRFS_dev fork.

## TESTS CONDUCTED: 
The app was built on Jet and UPP tested--it gives identical results to my tests compiling the authoritative UPP directly.

## DEPENDENCIES:
None

## DOCUMENTATION:
None