### PR TITLE
Update UPP hash

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -30,7 +30,7 @@ protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
 #branch = RRFS_dev
-hash = 7529528
+hash = 16331ae
 local_path = src/EMC_post
 required = True
 externals = None


### PR DESCRIPTION
This PR brings in the latest UPP code, which includes a bug fix for the GSL precip type algorithm (previously we were using run total accumulation, but should be using 1-h accumulation).

## TESTS CONDUCTED: 
The new code is running already in RRFS-B on Jet.  It was tested for the RRFS-B system in retrospective mode; the only changes were in the precip type fields, as expected.

## DEPENDENCIES:
None

## DOCUMENTATION:
None