### PR TITLE
add the bridge loan functionality to allow RRFS/RTMA works while waiting related PRs to be merged

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -61,5 +61,14 @@ hash = ecef5a2
 local_path = src/rrfs_utl
 required = True
 
+[rrfs_bridgeloan]
+protocol = git
+repo_url = https://github.com/NOAA-GSL/rrfs_bridgeloan.git
+# Specify either a branch name or a hash but not both.
+# branch = main
+hash = 7d95e89
+local_path = src/rrfs_bridgeloan
+required = True
+
 [externals_description]
 schema_version = 1.0.0

--- a/manage_externals/checkout_externals
+++ b/manage_externals/checkout_externals
@@ -29,6 +29,8 @@ if __name__ == '__main__':
     ARGS = manic.checkout.commandline_arguments()
     try:
         RET_STATUS, _ = manic.checkout.main(ARGS)
+        if os.path.isfile('src/rrfs_bridgeloan/bridge_loan.sh'):
+            os.system('src/rrfs_bridgeloan/bridge_loan.sh')
         if os.path.isfile('regional_workflow/Init.sh'):
             os.system('regional_workflow/Init.sh')
         sys.exit(RET_STATUS)


### PR DESCRIPTION
This works as a short-term lending mechanism employed until related Pull Requests are permanently merged into authoritative repositories. It allows users to meet current obligations by enabling real-time and on-demand retrospective experiments. 