### PR TITLE
update regional workflow and UPP to reduce number of ifi fields

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,9 +1,9 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/SamuelTrahanNOAA/regional_workflow
+repo_url = https://github.com/NOAA-GSL/ufs-srweather-app
 # Specify either a branch name or a hash but not both.
-branch = fewer-ifi-fields
-#hash = 848c2b17
+#branch = feature/RRFS_dev1
+hash = 54031813
 local_path = regional_workflow
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,9 +1,9 @@
 [regional_workflow]
 protocol = git
-repo_url = https://github.com/NOAA-GSL/regional_workflow
+repo_url = https://github.com/SamuelTrahanNOAA/regional_workflow
 # Specify either a branch name or a hash but not both.
-#branch = feature/RRFS_dev1
-hash = c3167d9
+branch = fewer-ifi-fields
+#hash = 848c2b17
 local_path = regional_workflow
 required = True
 
@@ -29,8 +29,8 @@ required = True
 protocol = git
 repo_url = https://github.com/NOAA-EMC/UPP
 # Specify either a branch name or a hash but not both.
-#branch = RRFS_dev
-hash = 762890a
+#branch = develop
+hash = ec3ca4c
 local_path = src/EMC_post
 required = True
 externals = None


### PR DESCRIPTION
This PR:

1. Updates to the latest UPP
2. Copies the latest post control files from that version of UPP to regional_workflow

* waiting on https://github.com/NOAA-GSL/regional_workflow/pull/565