### PR TITLE
Add "BLENDINGPYTHON" environment variable to env/build*intel*env for ...

### DIFF
--- a/env/build_hera_intel.env
+++ b/env/build_hera_intel.env
@@ -25,6 +25,7 @@ export CMAKE_C_COMPILER=mpiicc
 export CMAKE_CXX_COMPILER=mpiicpc
 export CMAKE_Fortran_COMPILER=mpiifort
 export CMAKE_Platform=hera.intel
+export BLENDINGPYTHON="/contrib/miniconda3/4.5.12/envs/pygraf/bin/python"
 
 # use shared memory and OpenFabrics Alliance (OFA) fabric with Intel MPI to circumvent RDMA-related bug in DAPL.
 export I_MPI_Platform=shm:ofa

--- a/env/build_jet_intel.env
+++ b/env/build_jet_intel.env
@@ -25,3 +25,4 @@ export CMAKE_C_COMPILER=mpiicc
 export CMAKE_CXX_COMPILER=mpiicpc
 export CMAKE_Fortran_COMPILER=mpiifort
 export CMAKE_Platform=jet.intel
+export BLENDINGPYTHON="/contrib/miniconda3/4.5.12/envs/pygraf/bin/python"

--- a/env/build_wcoss2_intel.env
+++ b/env/build_wcoss2_intel.env
@@ -51,6 +51,7 @@ module load nemsio/2.5.2
 module load libjpeg/9c
 module load cray-pals/1.1.3
 module load nco/5.0.6
+module load python/3.8.6
 
 #module use /lfs/h1/oar/esrl/noscrub/samuel.trahan/ifi/modulefiles
 #module try-load ifi/20221006-intel-19.1.3.304
@@ -62,4 +63,4 @@ export CMAKE_C_COMPILER=cc
 export CMAKE_CXX_COMPILER=CC
 export CMAKE_Fortran_COMPILER=ftn
 export CMAKE_Platform=wcoss2
-
+export BLENDINGPYTHON="/apps/spack/python/3.8.6/intel/19.1.3.304/pjn2nzkjvqgmjw4hmyz43v5x4jbxjzpk/bin/python"


### PR DESCRIPTION
…Hera/Jet/WCOSS2

## DESCRIPTION OF CHANGES: 
Add "BLENDINGPYTHON" environment variable to env/build*intel*env for Hera/Jet/WCOSS2. This is necessary for building the blending package in rrfs_utl.

## TESTS CONDUCTED: 
Tested on Hera, Jet, and WCOSS2.

## DEPENDENCIES:
https://github.com/NOAA-GSL/rrfs_utl/pull/38
https://github.com/NOAA-GSL/regional_workflow/pull/540 (will be replaced by PR in EMC's repo for [rrfs-workflow](https://github.com/NOAA-EMC/rrfs-workflow))

## DOCUMENTATION:
See other PRs for documentation on blending.

## CONTRIBUTORS (optional): 
Guoqing

